### PR TITLE
(maint): skip non-zunit files if recursing on a test directory

### DIFF
--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -396,6 +396,10 @@ function _zunit_parse_argument() {
   if [[ -d $argument ]]; then
     # Loop through each of the files in the directory
     for file in $(find $argument -mindepth 1 -maxdepth 1); do
+      # Skip further processing for files without a .zunit extension
+      if [[ -f $file && $file != *.zunit ]]; then
+        continue
+      fi
       # Run it through the parser again
       _zunit_parse_argument $file
     done


### PR DESCRIPTION
A new check is performed inside the directory recursion instead of inside the file check. This allows calling commands (e.g., `zunit test-file.weird_extension`) to still work. 

The `.zunit` extension requirement is only in place when doing directory recursion.