### PR TITLE
feat: add "-q/--quiet" flag to supress revolver spinner

### DIFF
--- a/src/commands/init.zsh
+++ b/src/commands/init.zsh
@@ -13,6 +13,7 @@ function _zunit_init_usage() {
   echo "  -h, --help         Output help text and exit"
   echo "  -v, --version      Output version information and exit"
   echo "  -t, --travis       Generate .travis.yml in project"
+  echo "  -g, --gh           Generate zunit.yml in project"
 }
 
 ###

--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -14,6 +14,8 @@ function _zunit_run_usage() {
   echo "  -v, --version          Output version information and exit"
   echo "  -f, --fail-fast        Stop the test runner immediately after the first failure"
   echo "  -t, --tap              Output results in a TAP compatible format"
+  echo "  -t, --tap              Output results in a TAP compatible format"
+  echo "  -q, --quiet            Supress revolver spinner for tests"
   echo "      --verbose          Prints full output from each test"
   echo "      --output-text      Print results to a text log, in TAP compatible format"
   echo "      --output-html      Print results to a HTML page"
@@ -47,12 +49,12 @@ function _zunit_output_results() {
   echo
   echo "$total tests run in $(_zunit_human_time $elapsed)"
   echo
-  echo "$(color yellow underline 'Results')                        "
-  echo "$(color green '✔') Passed      $passed                    "
-  echo "$(color red '✘') Failed      $failed                      "
-  echo "$(color red '‼') Errors      $errors                      "
-  echo "$(color magenta '●') Skipped     $skipped                 "
-  echo "$(color yellow '‼') Warnings    $warnings                 "
+  echo "$(color yellow  underline 'Results')                        "
+  echo "$(color green   '✔') Passed:   $passed                    "
+  echo "$(color red     '✘') Failed:   $failed                      "
+  echo "$(color red     '‼') Errors:   $errors                      "
+  echo "$(color magenta '●') Skipped:  $skipped                 "
+  echo "$(color yellow  '‼') Warnings: $warnings                 "
   echo
 
   [[ -n $output_text ]] && echo "TAP report written at $PWD/$logfile_text"

--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -69,7 +69,7 @@ function _zunit_execute_test() {
 
   if [[ -n $body ]] && [[ -n $name ]]; then
     # Update the progress indicator
-    [[ -z $tap ]] && revolver update "${name}"
+    [[ -z $tap ]] && [[ -z $quiet ]] && revolver update "${name}"
 
     # Make sure we don't already have a function defined
     (( $+functions[__zunit_tmp_test_function] )) && \
@@ -245,7 +245,7 @@ function _zunit_run_testfile() {
   test_names=()
 
   # Update status message
-  [[ -z $tap ]] && revolver update "Loading tests from $testfile"
+  [[ -z $tap ]] && [[ -z $quiet ]] && revolver update "Loading tests from $testfile"
 
   # A regex pattern to match test declarations
   pattern='^ *@test  *([^ ].*)  *\{ *(.*)$'
@@ -536,6 +536,12 @@ function _zunit_run() {
     verbose=1
   fi
 
+  # Quiet output is enabled
+  if [[ -n $quiet ]] || [[ "$zunit_config_quiet" = "true" ]]; then
+    # Set the $quiet variable, so we can check it later
+    quiet=1
+  fi
+
   # Check if time_limit is specified in the config or as an option
   if [[ -n $time_limit ]]; then
     shift time_limit
@@ -547,7 +553,7 @@ function _zunit_run() {
   testfiles=()
 
   # Start the progress indicator
-  [[ -z $tap ]] && revolver start 'Loading tests'
+  [[ -z $tap ]] && [[ -z $quiet ]] && revolver start 'Loading tests'
 
   # If no arguments are passed, try to work out where the tests are
   if [[ ${#arguments} -eq 0 ]]; then
@@ -583,7 +589,7 @@ function _zunit_run() {
   [[ -n $output_html ]] && _zunit_html_footer >> $logfile_html
 
   # Output results to screen and kill the progress indicator
-  [[ -z $tap ]] && _zunit_output_results && revolver stop
+  [[ -z $tap ]] && _zunit_output_results && [[ -z $quiet ]] && revolver stop
 
   # If the total of ($passed + $skipped) is not equal to the
   # total, then there must have been failures, errors or warnings,

--- a/src/events.zsh
+++ b/src/events.zsh
@@ -47,7 +47,7 @@ function _zunit_success() {
     return
   fi
 
-  echo "$(color green '✔') ${name}"
+  echo "$(color green 'PASS') ${name}"
 }
 
 ###
@@ -65,7 +65,7 @@ function _zunit_failure() {
   if [[ -n $tap ]]; then
     _zunit_tap_failure "$@"
   else
-    echo "$(color red '✘' ${name})"
+    echo "$(color red 'FAILURE' ${name})"
     echo "  $(color red underline ${message})"
     echo "  $(color red ${output})"
   fi
@@ -88,7 +88,7 @@ function _zunit_error() {
   if [[ -n $tap ]]; then
     _zunit_tap_error "$@"
   else
-    echo "$(color red '‼' ${name})"
+    echo "$(color red 'ERROR' ${name})"
     echo "  $(color red underline ${message})"
     echo "  $(color red ${output})"
   fi
@@ -113,7 +113,7 @@ function _zunit_warn() {
     return
   fi
 
-  echo "$(color yellow '‼') ${name}"
+  echo "$(color yellow 'WARNING') ${name}"
   echo "  $(color yellow underline ${message})"
 }
 

--- a/src/events.zsh
+++ b/src/events.zsh
@@ -8,7 +8,7 @@
 ###
 function _zunit_fail_shutdown() {
   # Kill the revolver process
-  [[ -z $tap ]] && revolver stop
+  [[ -z $tap ]] && [[ -z $quiet ]] && revolver stop
 
   # Print a message to screen
   echo $(color red bold 'Execution halted after failure')

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -22,6 +22,7 @@ function _zunit_usage() {
   echo "  -v, --version      Output version information and exit"
   echo "  -f, --fail-fast    Stop the test runner immediately after the first failure"
   echo "  -t, --tap          Output results in a TAP compatible format"
+  echo "  -q, --quiet        Supress revolver spinner for tests"
   echo "      --verbose      Prints full output from each test"
   echo "      --output-text  Print results to a text log, in TAP compatible format"
   echo "      --output-html  Print results to a HTML page"

--- a/zunit.zsh-completion
+++ b/zunit.zsh-completion
@@ -21,6 +21,7 @@ _zunit() {
     '(-v --version)'{-v,--version}'[show version information and exit]' \
     '(-f --fail-fast)'{-f,--fail-fast}'[stop execution after the first failure]' \
     '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]' \
+    '(-q --quiet)'{-q,--quiet}'[supress revolver spinner for tests]' \
     '--verbose[prints full output from each test]' \
     '--output-text[print results to a text log, in TAP compatible format]' \
     '--output-html[print results to a HTML page]' \
@@ -43,6 +44,7 @@ _zunit() {
             '(-h --help)'{-h,--help}'[show help text and exit]' \
             '(-f --fail-fast)'{-f,--fail-fast}'[stop execution after the first failure]' \
             '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]' \
+            '(-q --quiet)'{-q,--quiet}'[supress revolver spinner for tests]' \
             '--verbose[prints full output from each test]' \
             '--output-text[print results to a text log, in TAP compatible format]' \
             '--output-html[print results to a HTML page]' \


### PR DESCRIPTION
Currently, Zunit tests generate a lot of noise due to the revolver creating a new line for each spinner frame. 

This PR adds a flag (`-q`/`--quiet`) to suppress revolver to reduce noise and make it easier to grok test output.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>