### PR TITLE
fix: change test name to no styling for consistency

### DIFF
--- a/src/events.zsh
+++ b/src/events.zsh
@@ -47,7 +47,7 @@ function _zunit_success() {
     return
   fi
 
-  echo "$(color green bold 'PASS'): #$(color cyan ${passed}) $(color blue bold underline ${name})"
+  echo "$(color green bold 'PASS'): $(color cyan \#${passed}) ${name}"
 }
 
 ###
@@ -88,7 +88,7 @@ function _zunit_error() {
   if [[ -n $tap ]]; then
     _zunit_tap_error "$@"
   else
-    echo "$(color red 'ERROR' ${name})"
+    echo "$(color red bold 'ERROR' ${name})"
     echo "  $(color red underline ${message})"
     echo "  $(color red ${output})"
   fi
@@ -134,6 +134,6 @@ function _zunit_skip() {
     return
   fi
 
-  echo "$(color magenta 'SKIPPED'): ${name}"
+  echo "$(color magenta bold 'SKIPPED'): ${name}"
   echo "  \033[0;38;5;242m# ${message}\033[0;m"
 }


### PR DESCRIPTION
Side note: Zunit does not support using two format options at once

e.g., `echo "$( color blue bold underline 'foobar')"`