### PR TITLE
fix: use portable shebang for `configure` script

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 # vim: ft=zsh sw=4 ts=4 noet!
 target=Makefile
 arguments="$@"


### PR DESCRIPTION
* Changed the shebang line to use `/usr/bin/env zsh` instead of a hardcoded path, making the script more portable across different environments.